### PR TITLE
Adding the r5.16xlarge to the ebs optimized list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -212,6 +212,7 @@ locals {
     "r5d.large"    = true
     "r5d.xlarge"   = true
     "r5.12xlarge"  = true
+    "r5.16xlarge"  = true
     "r5.24xlarge"  = true
     "r5.2xlarge"   = true
     "r5.4xlarge"   = true


### PR DESCRIPTION
# PR o'clock

## Description

The r5.16xlarge is missing from the list

### Checklist

- [x] `terraform fmt` and `terraform validate` both work from the root and `examples/ebs_optimized_test_fixture` directories (look in CI for an example)
- [ ] Tests for the changes have been added and passing (for bug fixes/features)
- [ ] Test results are pasted in this PR (in lieu of CI)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] Any breaking changes are noted in the description above
